### PR TITLE
Fix AWS processing for missing product codes

### DIFF
--- a/aws-processing.py
+++ b/aws-processing.py
@@ -44,105 +44,121 @@ try:
 
         # Iterate through each AMI image
         for ami in ami_images['Images']:
-            # Check if AMI is BYOL and owned by the marketplace owner
-            if ami['ProductCodes'][0]['ProductCodeId'] == byol and ami['OwnerId'] == marketplace_owner_id:
-                # Extract the version number from the AMI name
-                # Check if the version is a hotfix (i.e. ends with "-hXX")
-                match = re.search(r'.*PA-VM-AWS-(\d+.\d+.\d+-h\d{1,2})-', ami['Name'])
-                if match:
-                    # Extract the version number from the match
-                    ver = match.group(1)
-                    list_of_byol.append(ver)
-                    if ver not in amis_by_version_byol:
-                        amis_by_version_byol[ver] = {}
-                    amis_by_version_byol[ver][region] = ami['ImageId']
-                else:
-                    # Split the AMI name by hyphens and extract the 4th element (i.e. the version number)
-                    ver = ami['Name'].split("-")[3]
-                    # Add the version number to the list of BYOL versions
-                    list_of_byol.append(ver)
-                    # If the version number is not already a key in the dictionary, add it
-                    if ver not in amis_by_version_byol:
-                        amis_by_version_byol[ver] = {}
-                    # Add the AMI ID to the dictionary, with the region as the key
-                    amis_by_version_byol[ver][region] = ami['ImageId']
+            # Check if 'ProductCodes' exists and is not empty
+            if 'ProductCodes' in ami and ami['ProductCodes']:
+                # Check if AMI is BYOL and owned by the marketplace owner
+                if ami['ProductCodes'][0]['ProductCodeId'] == byol and ami['OwnerId'] == marketplace_owner_id:
+                    # Extract the version number from the AMI name
+                    # Check if the version is a hotfix (i.e. ends with "-hXX")
+                    match = re.search(r'.*PA-VM-AWS-(\d+.\d+.\d+-h\d{1,2})-', ami['Name'])
+                    if match:
+                        # Extract the version number from the match
+                        ver = match.group(1)
+                        list_of_byol.append(ver)
+                        if ver not in amis_by_version_byol:
+                            amis_by_version_byol[ver] = {}
+                        amis_by_version_byol[ver][region] = ami['ImageId']
+                    else:
+                        # Split the AMI name by hyphens and extract the 4th element (i.e. the version number)
+                        ver = ami['Name'].split("-")[3]
+                        # Add the version number to the list of BYOL versions
+                        list_of_byol.append(ver)
+                        # If the version number is not already a key in the dictionary, add it
+                        if ver not in amis_by_version_byol:
+                            amis_by_version_byol[ver] = {}
+                        # Add the AMI ID to the dictionary, with the region as the key
+                        amis_by_version_byol[ver][region] = ami['ImageId']
+            else:
+                print(f"Skipping BYOL AMI {ami.get('ImageId', 'Unknown')} ({ami.get('Name', 'Unknown')}) in {region} due to missing ProductCode")
 
         # Iterate through each AMI image
         for ami in ami_images['Images']:
-            # Check if AMI is BUNDLE1 and owned by the marketplace owner
-            if ami['ProductCodes'][0]['ProductCodeId'] == bundle1 and ami['OwnerId'] == marketplace_owner_id:
-                # Extract the version number from the AMI name
-                # Check if the version is a hotfix (i.e. ends with "-hXX")
-                match = re.search(r'.*PA-VM-AWS-(\d+.\d+.\d+-h\d{1,2}|)-', ami['Name'])
-                if match:
-                    # Extract the version number from the match
-                    ver = match.group(1)
-                    list_of_bundle1.append(ver)
-                    if ver not in amis_by_version_bundle1:
-                        amis_by_version_bundle1[ver] = {}
-                    amis_by_version_bundle1[ver][region] = ami['ImageId']
-                else:
-                    # Split the AMI name by hyphens and extract the 4th element (i.e. the version number)
-                    ver = ami['Name'].split("-")[3]
-                    # Add the version number to the list of BUNDLE1 versions
-                    list_of_bundle1.append(ver)
-                    # If the version number is not already a key in the dictionary, add it
-                    if ver not in amis_by_version_bundle1:
-                        amis_by_version_bundle1[ver] = {}
-                    # Add the AMI ID to the dictionary, with the region as the key
-                    amis_by_version_bundle1[ver][region] = ami['ImageId']
+            # Check if 'ProductCodes' exists and is not empty
+            if 'ProductCodes' in ami and ami['ProductCodes']:
+                # Check if AMI is BUNDLE1 and owned by the marketplace owner
+                if ami['ProductCodes'][0]['ProductCodeId'] == bundle1 and ami['OwnerId'] == marketplace_owner_id:
+                    # Extract the version number from the AMI name
+                    # Check if the version is a hotfix (i.e. ends with "-hXX")
+                    match = re.search(r'.*PA-VM-AWS-(\d+.\d+.\d+-h\d{1,2}|)-', ami['Name'])
+                    if match:
+                        # Extract the version number from the match
+                        ver = match.group(1)
+                        list_of_bundle1.append(ver)
+                        if ver not in amis_by_version_bundle1:
+                            amis_by_version_bundle1[ver] = {}
+                        amis_by_version_bundle1[ver][region] = ami['ImageId']
+                    else:
+                        # Split the AMI name by hyphens and extract the 4th element (i.e. the version number)
+                        ver = ami['Name'].split("-")[3]
+                        # Add the version number to the list of BUNDLE1 versions
+                        list_of_bundle1.append(ver)
+                        # If the version number is not already a key in the dictionary, add it
+                        if ver not in amis_by_version_bundle1:
+                            amis_by_version_bundle1[ver] = {}
+                        # Add the AMI ID to the dictionary, with the region as the key
+                        amis_by_version_bundle1[ver][region] = ami['ImageId']
+            else:
+                print(f"Skipping Bundle1 AMI {ami.get('ImageId', 'Unknown')} ({ami.get('Name', 'Unknown')}) in {region} due to missing ProductCode")
 
         # Iterate through each AMI image
         for ami in ami_images['Images']:
-            # Check if AMI is BUNDLE2 and owned by the marketplace owner
-            if ami['ProductCodes'][0]['ProductCodeId'] == bundle2 and ami['OwnerId'] == marketplace_owner_id:
-                # Extract the version number from the AMI name
-                # Check if the version is a hotfix (i.e. ends with "-hXX")
-                match = re.search(r'.*PA-VM-AWS-(\d+.\d+.\d+-h\d{1,2})-', ami['Name'])
-                if match:
-                    # Extract the version number from the match
-                    ver = match.group(1)
-                    list_of_bundle2.append(ver)
-                    if ver not in amis_by_version_bundle2:
-                        amis_by_version_bundle2[ver] = {}
-                    amis_by_version_bundle2[ver][region] = ami['ImageId']
-                else:
-                    # Split the AMI name by hyphens and extract the 4th element (i.e. the version number)
-                    ver = ami['Name'].split("-")[3]
-                    # Add the version number to the list of BUNDLE2 versions
-                    list_of_bundle2.append(ver)
-                    # If the version number is not already a key in the dictionary, add it
-                    if ver not in amis_by_version_bundle2:
-                        amis_by_version_bundle2[ver] = {}
-                    # Add the AMI ID to the dictionary, with the region as the key
-                    amis_by_version_bundle2[ver][region] = ami['ImageId']
+            # Check if 'ProductCodes' exists and is not empty
+            if 'ProductCodes' in ami and ami['ProductCodes']:
+                # Check if AMI is BUNDLE2 and owned by the marketplace owner
+                if ami['ProductCodes'][0]['ProductCodeId'] == bundle2 and ami['OwnerId'] == marketplace_owner_id:
+                    # Extract the version number from the AMI name
+                    # Check if the version is a hotfix (i.e. ends with "-hXX")
+                    match = re.search(r'.*PA-VM-AWS-(\d+.\d+.\d+-h\d{1,2})-', ami['Name'])
+                    if match:
+                        # Extract the version number from the match
+                        ver = match.group(1)
+                        list_of_bundle2.append(ver)
+                        if ver not in amis_by_version_bundle2:
+                            amis_by_version_bundle2[ver] = {}
+                        amis_by_version_bundle2[ver][region] = ami['ImageId']
+                    else:
+                        # Split the AMI name by hyphens and extract the 4th element (i.e. the version number)
+                        ver = ami['Name'].split("-")[3]
+                        # Add the version number to the list of BUNDLE2 versions
+                        list_of_bundle2.append(ver)
+                        # If the version number is not already a key in the dictionary, add it
+                        if ver not in amis_by_version_bundle2:
+                            amis_by_version_bundle2[ver] = {}
+                        # Add the AMI ID to the dictionary, with the region as the key
+                        amis_by_version_bundle2[ver][region] = ami['ImageId']
+            else:
+                print(f"Skipping Bundle2 AMI {ami.get('ImageId', 'Unknown')} ({ami.get('Name', 'Unknown')}) in {region} due to missing ProductCode")
 
         ami_images = ec2.describe_images(Filters=[{'Name': 'name', 'Values': ['Panorama-AWS*']}])
 
         # Iterate through each AMI image
         for ami in ami_images['Images']:
-            # Check if AMI is BYOL and owned by the marketplace owner
-            if ami['ProductCodes'][0]['ProductCodeId'] == panorama and ami['OwnerId'] == marketplace_owner_id:
-                # Extract the version number from the AMI name
-                # Check if the version is a hotfix (i.e. ends with "-hXX")
-                match = re.search(r'.*Panorama-AWS-(\d+.\d+.\d-h\d{1,2})-[a-z|0-9|-]{36}', ami['Name'])
-                if match:
-                    # Extract the version number from the match
-                    ver = match.group(1)
-                    list_of_panorama.append(ver)
-                    if ver not in amis_by_version_panorama:
-                        amis_by_version_panorama[ver] = {}
-                    amis_by_version_panorama[ver][region] = ami['ImageId']
-                else:
-                    # Split the AMI name by hyphens and extract the 3th element (i.e. the version number)
-                    ver = ami['Name'].split("-")[2]
-                    # Add the version number to the list of BYOL versions
-                    list_of_panorama.append(ver)
-                    # If the version number is not already a key in the dictionary, add it
-                    if ver not in amis_by_version_panorama:
-                        amis_by_version_panorama[ver] = {}
-                    # Add the AMI ID to the dictionary, with the region as the key
-                    amis_by_version_panorama[ver][region] = ami['ImageId']                    
+            # Check if 'ProductCodes' exists and is not empty
+            if 'ProductCodes' in ami and ami['ProductCodes']:
+                # Check if AMI is BYOL and owned by the marketplace owner
+                if ami['ProductCodes'][0]['ProductCodeId'] == panorama and ami['OwnerId'] == marketplace_owner_id:
+                    # Extract the version number from the AMI name
+                    # Check if the version is a hotfix (i.e. ends with "-hXX")
+                    match = re.search(r'.*Panorama-AWS-(\d+.\d+.\d-h\d{1,2})-[a-z|0-9|-]{36}', ami['Name'])
+                    if match:
+                        # Extract the version number from the match
+                        ver = match.group(1)
+                        list_of_panorama.append(ver)
+                        if ver not in amis_by_version_panorama:
+                            amis_by_version_panorama[ver] = {}
+                        amis_by_version_panorama[ver][region] = ami['ImageId']
+                    else:
+                        # Split the AMI name by hyphens and extract the 3th element (i.e. the version number)
+                        ver = ami['Name'].split("-")[2]
+                        # Add the version number to the list of BYOL versions
+                        list_of_panorama.append(ver)
+                        # If the version number is not already a key in the dictionary, add it
+                        if ver not in amis_by_version_panorama:
+                            amis_by_version_panorama[ver] = {}
+                        # Add the AMI ID to the dictionary, with the region as the key
+                        amis_by_version_panorama[ver][region] = ami['ImageId']
+            else:
+                print(f"Skipping Panorama AMI {ami.get('ImageId', 'Unknown')} ({ami.get('Name', 'Unknown')}) in {region} due to missing ProductCode")
 
     list_of_byol = list(dict.fromkeys(list_of_byol))
     list_of_byol.sort(key=semver.Version.parse)


### PR DESCRIPTION
New images have been released which have no `ProductCodes`, so adding a new conditional to stop this scenario breaking the workflow